### PR TITLE
fix: strengthen ALLOWED_ORGS/ALLOWED_REPOS lockdown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,26 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run filter.py unit tests
+        run: pytest test_filter.py -v
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: read
       packages: write

--- a/filter.py
+++ b/filter.py
@@ -24,6 +24,8 @@ Access-control logic
 * A tool call is allowed when the owner matches ANY pattern in ALLOWED_ORGS
   OR the full "owner/repo" matches ANY pattern in ALLOWED_REPOS.
 * Tools that carry no owner/repo arguments (e.g. get_me) are always allowed.
+* When ALLOWED_ORGS or ALLOWED_REPOS is set, tool calls that supply `repo`
+  but omit `owner` are rejected (ambiguous — owner is required for matching).
 * search_* tools use a free-text query string; org/repo filtering is NOT
   applied to their arguments — rely on PAT scoping for those.
 """
@@ -81,11 +83,34 @@ ALLOWED_REPOS: list[str] = [
     r.strip() for r in os.environ.get("ALLOWED_REPOS", "").split(",") if r.strip()
 ]
 
+# ---------------------------------------------------------------------------
+# Synthetic tool: get_access_policy
+# Injected into tools/list responses and handled locally (never forwarded).
+# ---------------------------------------------------------------------------
+_GET_ACCESS_POLICY_TOOL: dict = {
+    "name": "get_access_policy",
+    "description": (
+        "Returns the active MCP access-control policy: tool allowlist, "
+        "permanently blocked tools, and org/repo restrictions."
+    ),
+    "inputSchema": {"type": "object", "properties": {}, "required": []},
+}
+
+# ---------------------------------------------------------------------------
+# State for tools/list response injection (thread-safe)
+# ---------------------------------------------------------------------------
+_tools_list_ids: set = set()
+_tools_list_lock = threading.Lock()
+
 
 def is_allowed(owner: str | None, repo: str | None) -> bool:
     """Return True if the owner/repo combination is permitted."""
     if not ALLOWED_ORGS and not ALLOWED_REPOS:
         return True  # no restrictions configured
+
+    # repo without owner is ambiguous — reject when restrictions are active
+    if repo and not owner:
+        return False
 
     if owner:
         for pattern in ALLOWED_ORGS:
@@ -113,16 +138,54 @@ def make_error(msg_id: object, text: str) -> bytes:
     return (json.dumps(resp) + "\n").encode()
 
 
+def make_result(msg_id: object, content: object) -> bytes:
+    resp = {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": content,
+    }
+    return (json.dumps(resp) + "\n").encode()
+
+
+def handle_get_access_policy(msg_id: object) -> bytes:
+    """Synthesise a tools/call result for the get_access_policy tool."""
+    policy = {
+        "allowed_tools": sorted(ALLOWED_TOOLS),
+        "blocked_tools": sorted(BLOCKED_TOOLS),
+        "allowed_orgs": ALLOWED_ORGS,
+        "allowed_repos": ALLOWED_REPOS,
+        "mode": "restricted" if (ALLOWED_ORGS or ALLOWED_REPOS) else "passthrough",
+    }
+    return make_result(
+        msg_id,
+        {"content": [{"type": "text", "text": json.dumps(policy, indent=2)}]},
+    )
+
+
 def check_message(msg: dict) -> bytes | None:
     """
-    Returns an encoded error response if the message should be blocked,
+    Returns an encoded response if the message should be intercepted,
     or None if it should be forwarded to github-mcp-server.
     """
-    if msg.get("method") != "tools/call":
+    method = msg.get("method")
+
+    # Track tools/list requests so we can inject our synthetic tool later.
+    if method == "tools/list":
+        msg_id = msg.get("id")
+        if msg_id is not None:
+            with _tools_list_lock:
+                _tools_list_ids.add(msg_id)
+        return None  # forward to upstream
+
+    if method != "tools/call":
         return None
 
     params = msg.get("params", {})
     tool_name: str | None = params.get("name")
+
+    # Synthetic tool: handle locally before any allowlist check.
+    if tool_name == "get_access_policy":
+        return handle_get_access_policy(msg.get("id"))
 
     # Hard block: permanently forbidden tools regardless of GITHUB_TOOLS.
     if tool_name in BLOCKED_TOOLS:
@@ -154,6 +217,39 @@ def check_message(msg: dict) -> bytes | None:
     return None
 
 
+def inject_synthetic_tools(line: bytes) -> bytes:
+    """
+    If *line* is a tools/list response for a tracked request ID, inject
+    the get_access_policy synthetic tool into the tools list.
+    Returns the (possibly modified) line.
+    """
+    try:
+        resp = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return line
+
+    msg_id = resp.get("id")
+    with _tools_list_lock:
+        is_tracked = msg_id in _tools_list_ids
+        if is_tracked:
+            _tools_list_ids.discard(msg_id)
+
+    if not is_tracked or "result" not in resp:
+        return line
+
+    result = resp["result"]
+    if not isinstance(result, dict):
+        return line
+
+    tools = result.get("tools")
+    if not isinstance(tools, list):
+        return line
+
+    tools.append(_GET_ACCESS_POLICY_TOOL)
+    result["tools"] = tools
+    return (json.dumps(resp) + "\n").encode()
+
+
 def main() -> None:
     proc = subprocess.Popen(
         ["github-mcp-server", "stdio"],
@@ -166,6 +262,7 @@ def main() -> None:
         try:
             assert proc.stdout is not None
             for line in proc.stdout:
+                line = inject_synthetic_tools(line)
                 sys.stdout.buffer.write(line)
                 sys.stdout.buffer.flush()
         except BrokenPipeError:
@@ -180,9 +277,9 @@ def main() -> None:
                 continue
             try:
                 msg = json.loads(raw_line)
-                error_resp = check_message(msg)
-                if error_resp:
-                    sys.stdout.buffer.write(error_resp)
+                intercept_resp = check_message(msg)
+                if intercept_resp:
+                    sys.stdout.buffer.write(intercept_resp)
                     sys.stdout.buffer.flush()
                 else:
                     proc.stdin.write(raw_line)

--- a/test_filter.py
+++ b/test_filter.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for filter.py access-control logic.
+
+Run with:  pytest test_filter.py -v
+"""
+
+import json
+import pytest
+import filter as f
+
+
+@pytest.fixture(autouse=True)
+def reset_tools_list_ids():
+    """Ensure _tools_list_ids is clean before and after every test."""
+    f._tools_list_ids.clear()
+    yield
+    f._tools_list_ids.clear()
+
+
+# ---------------------------------------------------------------------------
+# is_allowed()
+# ---------------------------------------------------------------------------
+
+
+class TestIsAllowed:
+    def test_no_restrictions_permits_all(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        assert f.is_allowed(None, None) is True
+        assert f.is_allowed("anyorg", "anyrepo") is True
+        assert f.is_allowed(None, "anyrepo") is True
+
+    def test_repo_without_owner_rejected_when_orgs_restricted(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        assert f.is_allowed(None, "somerepo") is False
+
+    def test_repo_without_owner_rejected_when_repos_restricted(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", ["myorg/somerepo"])
+        assert f.is_allowed(None, "somerepo") is False
+
+    def test_owner_in_allowed_orgs_permitted(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        assert f.is_allowed("myorg", "anyrepo") is True
+
+    def test_owner_not_in_allowed_orgs_denied(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        assert f.is_allowed("badorg", "anyrepo") is False
+
+    def test_org_glob_pattern_matches(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["partner-*"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        assert f.is_allowed("partner-foo", "repo") is True
+        assert f.is_allowed("partner-bar", "repo") is True
+        assert f.is_allowed("other-foo", "repo") is False
+
+    def test_repo_in_allowed_repos_permitted(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", ["myorg/specific"])
+        assert f.is_allowed("myorg", "specific") is True
+        assert f.is_allowed("myorg", "other") is False
+
+    def test_repo_glob_pattern_matches(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", ["myorg/*"])
+        assert f.is_allowed("myorg", "anything") is True
+        assert f.is_allowed("other", "anything") is False
+
+    def test_owner_only_no_repo_with_orgs_allowed(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        assert f.is_allowed("myorg", None) is True
+
+    def test_owner_only_no_repo_with_repos_only_denied(self, monkeypatch):
+        # Only ALLOWED_REPOS configured — no repo argument means no match
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", ["myorg/repo"])
+        assert f.is_allowed("myorg", None) is False
+
+    def test_allowed_via_repos_not_orgs(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["otherorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", ["myorg/myrepo"])
+        assert f.is_allowed("myorg", "myrepo") is True  # matches ALLOWED_REPOS
+        assert f.is_allowed("myorg", "other") is False
+
+
+# ---------------------------------------------------------------------------
+# check_message()
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMessage:
+    def test_non_tools_call_forwarded(self):
+        msg = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        assert f.check_message(msg) is None
+
+    def test_notifications_forwarded(self):
+        msg = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        assert f.check_message(msg) is None
+
+    def test_blocked_tool_rejected(self):
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "merge_pull_request", "arguments": {}},
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        assert "error" in parsed
+        assert "permanently disabled" in parsed["error"]["message"]
+
+    def test_tool_not_in_allowlist_rejected(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_me"}))
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "delete_file", "arguments": {}},
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        assert "error" in parsed
+        assert "not permitted" in parsed["error"]["message"]
+
+    def test_allowed_tool_no_owner_repo_forwarded(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_me"}))
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "get_me", "arguments": {}},
+        }
+        assert f.check_message(msg) is None
+
+    def test_repo_without_owner_rejected_when_restricted(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_file_contents"}))
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "get_file_contents",
+                "arguments": {"repo": "somerepo"},
+            },
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        assert "error" in parsed
+        assert "Access denied" in parsed["error"]["message"]
+
+    def test_owner_in_allowlist_forwarded(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_file_contents"}))
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "get_file_contents",
+                "arguments": {"owner": "myorg", "repo": "myrepo"},
+            },
+        }
+        assert f.check_message(msg) is None
+
+    def test_owner_not_in_allowlist_rejected(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_file_contents"}))
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "get_file_contents",
+                "arguments": {"owner": "badorg", "repo": "repo"},
+            },
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        assert "error" in parsed
+
+    def test_get_access_policy_returns_result_restricted(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", ["myorg"])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", ["myorg/repo"])
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_me"}))
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/call",
+            "params": {"name": "get_access_policy", "arguments": {}},
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        assert "result" in parsed
+        assert "error" not in parsed
+        assert parsed["id"] == 42
+        policy = json.loads(parsed["result"]["content"][0]["text"])
+        assert policy["mode"] == "restricted"
+        assert "myorg" in policy["allowed_orgs"]
+        assert "myorg/repo" in policy["allowed_repos"]
+        assert "get_me" in policy["allowed_tools"]
+
+    def test_get_access_policy_returns_passthrough_mode(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_me"}))
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_access_policy", "arguments": {}},
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        policy = json.loads(parsed["result"]["content"][0]["text"])
+        assert policy["mode"] == "passthrough"
+
+    def test_get_access_policy_bypasses_tool_allowlist(self, monkeypatch):
+        # get_access_policy should work even if it's not in ALLOWED_TOOLS
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset())  # nothing allowed
+        monkeypatch.setattr(f, "ALLOWED_ORGS", [])
+        monkeypatch.setattr(f, "ALLOWED_REPOS", [])
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_access_policy", "arguments": {}},
+        }
+        resp = f.check_message(msg)
+        assert resp is not None
+        parsed = json.loads(resp)
+        assert "result" in parsed
+
+    def test_tools_list_request_tracked(self):
+        msg = {"jsonrpc": "2.0", "id": 7, "method": "tools/list", "params": {}}
+        result = f.check_message(msg)
+        assert result is None  # forwarded to upstream
+        assert 7 in f._tools_list_ids
+
+    def test_tools_list_notification_not_tracked(self):
+        # Notifications have no id — should not add None to tracking set
+        msg = {"jsonrpc": "2.0", "method": "tools/list", "params": {}}
+        f.check_message(msg)
+        assert None not in f._tools_list_ids
+
+    def test_error_response_preserves_id(self, monkeypatch):
+        monkeypatch.setattr(f, "ALLOWED_TOOLS", frozenset({"get_me"}))
+        msg = {
+            "jsonrpc": "2.0",
+            "id": "req-abc",
+            "method": "tools/call",
+            "params": {"name": "merge_pull_request", "arguments": {}},
+        }
+        resp = f.check_message(msg)
+        parsed = json.loads(resp)
+        assert parsed["id"] == "req-abc"
+
+
+# ---------------------------------------------------------------------------
+# inject_synthetic_tools()
+# ---------------------------------------------------------------------------
+
+
+class TestInjectSyntheticTools:
+    def test_non_json_line_unchanged(self):
+        line = b"not json\n"
+        assert f.inject_synthetic_tools(line) == line
+
+    def test_untracked_id_unchanged(self):
+        resp = {"jsonrpc": "2.0", "id": 99, "result": {"tools": [{"name": "get_me"}]}}
+        line = (json.dumps(resp) + "\n").encode()
+        assert f.inject_synthetic_tools(line) == line
+
+    def test_tracked_tools_list_gets_injected(self):
+        f._tools_list_ids.add(5)
+        resp = {"jsonrpc": "2.0", "id": 5, "result": {"tools": [{"name": "get_me"}]}}
+        line = (json.dumps(resp) + "\n").encode()
+        result = f.inject_synthetic_tools(line)
+        parsed = json.loads(result)
+        tool_names = [t["name"] for t in parsed["result"]["tools"]]
+        assert "get_access_policy" in tool_names
+        assert "get_me" in tool_names
+
+    def test_tracked_id_consumed_only_once(self):
+        f._tools_list_ids.add(5)
+        resp = {"jsonrpc": "2.0", "id": 5, "result": {"tools": []}}
+        line = (json.dumps(resp) + "\n").encode()
+        f.inject_synthetic_tools(line)  # first call — injects and removes ID
+        # second call — ID is gone, should not inject again
+        resp2 = {"jsonrpc": "2.0", "id": 5, "result": {"tools": []}}
+        line2 = (json.dumps(resp2) + "\n").encode()
+        result2 = f.inject_synthetic_tools(line2)
+        parsed2 = json.loads(result2)
+        assert parsed2 == resp2  # unchanged
+
+    def test_error_response_not_modified(self):
+        f._tools_list_ids.add(5)
+        resp = {"jsonrpc": "2.0", "id": 5, "error": {"code": -32600, "message": "err"}}
+        line = (json.dumps(resp) + "\n").encode()
+        result = f.inject_synthetic_tools(line)
+        parsed = json.loads(result)
+        assert "result" not in parsed
+        assert "error" in parsed
+
+    def test_result_without_tools_key_unchanged(self):
+        f._tools_list_ids.add(5)
+        resp = {"jsonrpc": "2.0", "id": 5, "result": {"other": "data"}}
+        line = (json.dumps(resp) + "\n").encode()
+        result = f.inject_synthetic_tools(line)
+        parsed = json.loads(result)
+        assert "tools" not in parsed["result"]
+
+    def test_injected_tool_has_correct_name(self):
+        f._tools_list_ids.add(10)
+        resp = {"jsonrpc": "2.0", "id": 10, "result": {"tools": []}}
+        line = (json.dumps(resp) + "\n").encode()
+        result = f.inject_synthetic_tools(line)
+        parsed = json.loads(result)
+        injected = parsed["result"]["tools"][0]
+        assert injected["name"] == "get_access_policy"
+        assert "inputSchema" in injected
+        assert "description" in injected


### PR DESCRIPTION
## Summary

Closes #5.

- **Gap #1 fix**: `is_allowed()` now explicitly rejects calls that supply `repo` but omit `owner` when any allowlist is configured — previously these slipped through.
- **Synthetic `get_access_policy` tool**: intercepted locally before the allowlist check; returns the active policy (`mode`, `allowed_orgs`, `allowed_repos`, `allowed_tools`, `blocked_tools`). Injected into `tools/list` responses so MCP clients can discover it.
- **32 pytest unit tests** covering `is_allowed()`, `check_message()`, and `inject_synthetic_tools()`.
- **README** updated with the complete access-control model, recommended configuration patterns, and `get_access_policy` docs.
- **CI**: new `test` job runs pytest before the Docker build; `build-and-push` has `needs: test`.

## Test plan

- [ ] `pytest test_filter.py -v` passes locally (32/32)
- [ ] CI `test` job passes on this PR
- [ ] Call `get_access_policy` via MCP client — confirm policy JSON is returned
- [ ] Set `ALLOWED_ORGS=myorg`, send a call with `repo` but no `owner` — confirm rejection
- [ ] Verify `get_access_policy` appears in `tools/list` response from the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)